### PR TITLE
feat: display github hash in the footer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ ASP_JWT_SECRET= # API JWT secret from ASP
 NEXT_PUBLIC_TEST_MODE= # Example: true
 NEXT_PUBLIC_SHOW_DISCLAIMER= # Example: true
 NEXT_PUBLIC_IS_TESTNET= # Example: true
+NEXT_PUBLIC_GITHUB_HASH= # Example: "4fdc156"

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -9,6 +9,10 @@ const constants: Constants = {
       label: 'Support',
       href: 'https://docs.google.com/forms/d/e/1FAIpQLSe0UKiTrZ4kD0apx75bEW0PWqJxpd6bCYh_IUKBrCkJOBzkpQ/viewform',
     },
+    {
+      label: 'Github',
+      href: `https://github.com/0xbow-io/privacy-pools-website`,
+    },
   ],
   ASP_OPTIONS: ['0xBow ASP'],
   COOKIES: {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -8,6 +8,7 @@ const env: Env = {
   TEST_MODE: process.env.NEXT_PUBLIC_TEST_MODE === 'true',
   SHOW_DISCLAIMER: process.env.NEXT_PUBLIC_SHOW_DISCLAIMER === 'true',
   IS_TESTNET: process.env.NEXT_PUBLIC_IS_TESTNET === 'true',
+  GITHUB_HASH: process.env.NEXT_PUBLIC_GITHUB_HASH as string,
 };
 
 export const getServerEnv = () => {

--- a/src/containers/Footer.tsx
+++ b/src/containers/Footer.tsx
@@ -79,7 +79,7 @@ const VBar = styled('span')(({ theme }) => {
 const LinkHash = styled('span')(({ theme }) => {
   return {
     span: {
-      fontSize: '10px',
+      fontSize: '1rem',
       color: theme.palette.text.primary,
       padding: '0.2rem 0.8rem',
       borderRadius: '1rem',

--- a/src/containers/Footer.tsx
+++ b/src/containers/Footer.tsx
@@ -6,7 +6,10 @@ import { styled } from '@mui/material';
 import { getConfig } from '~/config';
 
 export const Footer = () => {
-  const { FOOTER_LINKS } = getConfig().constants;
+  const {
+    constants: { FOOTER_LINKS },
+    env: { GITHUB_HASH },
+  } = getConfig();
 
   return (
     <FooterContainer>
@@ -15,7 +18,12 @@ export const Footer = () => {
           <Fragment key={item.label}>
             <LinkItem>
               <Link href={item.href} target='_blank'>
-                {item.label}
+                {item.label !== 'Github' && item.label}
+                {item.label === 'Github' && (
+                  <LinkHash>
+                    {item.label} {GITHUB_HASH && <span>{GITHUB_HASH}</span>}
+                  </LinkHash>
+                )}{' '}
               </Link>
             </LinkItem>
             {i < FOOTER_LINKS.length - 1 && <VBar>|</VBar>}
@@ -65,5 +73,17 @@ const LinkItem = styled('li')(({ theme }) => {
 const VBar = styled('span')(({ theme }) => {
   return {
     color: theme.palette.text.disabled,
+  };
+});
+
+const LinkHash = styled('span')(({ theme }) => {
+  return {
+    span: {
+      fontSize: '10px',
+      color: theme.palette.text.primary,
+      padding: '0.2rem 0.8rem',
+      borderRadius: '1rem',
+      border: `1px solid ${theme.palette.text.primary}`,
+    },
   };
 });

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -8,6 +8,7 @@ export interface Env {
   TEST_MODE: boolean;
   SHOW_DISCLAIMER: boolean;
   IS_TESTNET: boolean;
+  GITHUB_HASH: string;
 }
 
 export interface Constants {


### PR DESCRIPTION
## Describe your changes

- add `GITHUB_HASH` env variable
- display the GITHUB_HASH
- prevent errors if GITHUB_HASH is missing

<img width="641" alt="Captura de pantalla 2025-05-07 a la(s) 11 50 21 a  m" src="https://github.com/user-attachments/assets/63ba7c54-96f6-40c7-8432-961a427c31fe" />


## Issue ticket number and link

https://linear.app/defi-wonderland/issue/0XB-401/display-github-hash

closes 0XB-401

## Checklist before requesting a review

- [ ] I have conducted a self-review of my code.
- [ ] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.
