### PR TITLE
fix: PA's three-dots menu modal shifts position unexpectedly

### DIFF
--- a/src/components/PoolAccountTable.tsx
+++ b/src/components/PoolAccountTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, MouseEvent } from 'react';
+import { useState, MouseEvent, useEffect } from 'react';
 import { OverflowMenuVertical } from '@carbon/icons-react';
 import {
   styled,
@@ -37,6 +37,12 @@ export const PoolAccountTable = ({ records }: { records: PoolAccount[] }) => {
 
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  useEffect(() => {
+    if (isLoading || !records.length) {
+      setAnchorEl([]);
+    }
+  }, [isLoading, records.length]);
 
   const handleToggle = (event: MouseEvent<HTMLElement>, index: number) => {
     const newAnchorEl = Array(poolAccounts.length).fill(null);


### PR DESCRIPTION
## Describe your changes

PA's three-dots menu modal shifts position unexpectedly fixed

https://github.com/user-attachments/assets/c772ca58-7087-485e-a82e-48cd0f8068f6

## Issue ticket number and link

closes 0XB-404

https://linear.app/defi-wonderland/issue/0XB-404/pas-three-dots-menu-modal-shifts-position-unexpectedly

## Checklist before requesting a review

- [ ] I have conducted a self-review of my code.
- [ ] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.
