### PR TITLE
fix: incorrect token modal + issues related to decimals

### DIFF
--- a/src/containers/GlobalPool.tsx
+++ b/src/containers/GlobalPool.tsx
@@ -7,11 +7,14 @@ import { useExternalServices, useChainContext } from '~/hooks';
 
 export const GlobalPool = () => {
   const {
-    balanceBN: { symbol, decimals },
+    balanceBN: { symbol, decimals: balanceDecimals },
+    selectedPoolInfo: { assetDecimals },
   } = useChainContext();
   const {
     aspData: { poolsData },
   } = useExternalServices();
+
+  const decimals = assetDecimals ?? balanceDecimals ?? 18;
 
   const poolBalance = Number(formatUnits(BigInt(poolsData?.totalInPoolValue || 0), decimals)).toFixed(2);
 

--- a/src/containers/Modals/ActivityDetails/DataSection.tsx
+++ b/src/containers/Modals/ActivityDetails/DataSection.tsx
@@ -9,10 +9,9 @@ import { formatDataNumber, formatTimestamp, getUsdBalance, truncateAddress } fro
 
 export const DataSection = () => {
   const {
-    chain: { symbol },
-    selectedPoolInfo,
+    selectedPoolInfo: { assetDecimals, asset, entryPointAddress },
+    balanceBN: { decimals: balanceDecimals },
     price,
-    balanceBN: { decimals },
   } = useChainContext();
   const { vettingFeeBPS, selectedHistoryData } = usePoolAccountsContext();
   const { currentSelectedRelayerData } = useExternalServices();
@@ -28,6 +27,8 @@ export const DataSection = () => {
   // const fromAddress = isDeposit ? selectedHistoryData?.address : '';
   // const toAddress = isDeposit ? '' : selectedHistoryData?.address;
 
+  const decimals = assetDecimals ?? balanceDecimals ?? 18;
+
   const feeBps = isDeposit ? vettingFeeBPS : BigInt(currentSelectedRelayerData?.fees ?? 0n);
   const amountInWei = BigInt(selectedHistoryData?.amount ?? 0n);
 
@@ -38,20 +39,18 @@ export const DataSection = () => {
 
   const feeFormatted = formatDataNumber(fees, decimals);
   const feeUSD = getUsdBalance(price, formatUnits(fees, decimals), decimals);
-  const feeText = `${feeFormatted} ${symbol} (~ ${feeUSD} USD)`;
+  const feeText = `${feeFormatted} ${asset} (~ ${feeUSD} USD)`;
 
-  const feesCollectorAddress = isDeposit
-    ? selectedPoolInfo.entryPointAddress
-    : currentSelectedRelayerData?.relayerAddress;
+  const feesCollectorAddress = isDeposit ? entryPointAddress : currentSelectedRelayerData?.relayerAddress;
   const feesCollector = `OxBow (${truncateAddress(feesCollectorAddress ?? '0x')})`;
 
   const totalText = isDeposit ? formatUnits(originalAmount, decimals) : formatUnits(amountInWei, decimals);
   const totalUSD = getUsdBalance(price, totalText, decimals);
-  const valueText = `~${totalText.slice(0, 6)} ${symbol} (~ ${totalUSD} USD)`;
+  const valueText = `~${totalText.slice(0, 6)} ${asset} (~ ${totalUSD} USD)`;
 
   const amountWithFee = originalAmount - fees;
   const amountWithFeeUSD = getUsdBalance(price, formatUnits(amountWithFee, decimals), decimals);
-  const receivedText = `${formatUnits(amountWithFee, decimals)} ${symbol} (~ ${amountWithFeeUSD} USD)`;
+  const receivedText = `${formatUnits(amountWithFee, decimals)} ${asset} (~ ${amountWithFeeUSD} USD)`;
 
   // const poolAccountName = useMemo(() => {
   //   const name = poolAccounts.find((pool) => pool.label === selectedHistoryData?.commitment?.preimage?.label)?.name;

--- a/src/containers/Modals/ActivityDetails/Resume.tsx
+++ b/src/containers/Modals/ActivityDetails/Resume.tsx
@@ -13,9 +13,11 @@ export const Resume = () => {
   const { selectedHistoryData } = usePoolAccountsContext();
   const {
     price,
-    chain,
-    balanceBN: { decimals },
+    balanceBN: { decimals: balanceDecimals },
+    selectedPoolInfo: { assetDecimals, asset },
   } = useChainContext();
+
+  const decimals = assetDecimals ?? balanceDecimals ?? 18;
 
   const amount = formatUnits(selectedHistoryData?.amount ?? 0n, decimals);
   const usdBalance = getUsdBalance(price, formatUnits(selectedHistoryData?.amount ?? 0n, decimals), decimals);
@@ -34,7 +36,7 @@ export const Resume = () => {
       <Stack direction='column' alignItems='start' gap='0.8rem'>
         <EthText variant='h6'>
           {amount}
-          <span>{chain.symbol}</span>
+          <span>{asset}</span>
         </EthText>
         <BalanceUsd variant='body2'>{`~ ${usdBalance}`}</BalanceUsd>
       </Stack>

--- a/src/containers/Modals/Withdraw/WithdrawForm.tsx
+++ b/src/containers/Modals/Withdraw/WithdrawForm.tsx
@@ -30,7 +30,7 @@ export const WithdrawForm = () => {
 
   const {
     chain: { image },
-    balanceBN: { symbol, decimals },
+    balanceBN: { symbol, decimals: balanceDecimals },
     selectedPoolInfo,
     chainId,
     selectedRelayer,
@@ -44,6 +44,8 @@ export const WithdrawForm = () => {
   const { amount, setAmount, target, setTarget, poolAccount, setPoolAccount, setFeeCommitment, setFeeBPSForWithdraw } =
     usePoolAccountsContext();
   const { poolAccounts } = useAccountContext();
+
+  const decimals = selectedPoolInfo?.assetDecimals ?? balanceDecimals ?? 18;
 
   const filteredPoolAccounts = poolAccounts.filter((pa) => pa.balance > 0n);
 


### PR DESCRIPTION
## Describe your changes

- Incorrect token symbol displayed in transaction details modals (Activity section)
- Wrong remaining PA amount when using “Withdraw” button
- Global pool amount decimals issue

https://github.com/user-attachments/assets/969bbb49-c0b2-4f43-8ff8-209f16c04b0c




## Issue ticket number and link

closes 0XB-412 0XB-414

https://linear.app/defi-wonderland/issue/0XB-412/wrong-remaining-pa-amount-when-using-withdraw-button
https://linear.app/defi-wonderland/issue/0XB-414/incorrect-token-symbol-displayed-in-transaction-details-modals

## Checklist before requesting a review

- [ ] I have conducted a self-review of my code.
- [ ] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.
