### PR TITLE
fix: load accounts outdated + view all button fix

### DIFF
--- a/src/containers/PoolAccountsPreview.tsx
+++ b/src/containers/PoolAccountsPreview.tsx
@@ -27,7 +27,7 @@ export const PoolAccountsPreview = () => {
   } = useAccountContext();
   const { previewPoolAccounts } = useAdvancedView();
   const { setModalOpen } = useModal();
-  const { isLogged, isConnected } = useAuthContext();
+  const { isLogged, isConnected, isAuthorized } = useAuthContext();
   const goTo = useGoTo();
 
   const handleShowEmptyPools = () => {
@@ -92,7 +92,7 @@ export const PoolAccountsPreview = () => {
                 </ViewAllButton>
               )}
 
-              {isConnected && isLogged && (
+              {isAuthorized && (
                 <ViewAllButton
                   onClick={handleNavigateToPoolAccounts}
                   disabled={poolsByAssetAndChain && !poolsByAssetAndChain.length}

--- a/src/containers/PoolAccountsPreview.tsx
+++ b/src/containers/PoolAccountsPreview.tsx
@@ -92,12 +92,14 @@ export const PoolAccountsPreview = () => {
                 </ViewAllButton>
               )}
 
-              <ViewAllButton
-                onClick={handleNavigateToPoolAccounts}
-                disabled={poolsByAssetAndChain && !poolsByAssetAndChain.length}
-              >
-                <ViewAllText>View All</ViewAllText>
-              </ViewAllButton>
+              {isConnected && isLogged && (
+                <ViewAllButton
+                  onClick={handleNavigateToPoolAccounts}
+                  disabled={poolsByAssetAndChain && !poolsByAssetAndChain.length}
+                >
+                  <ViewAllText>View All</ViewAllText>
+                </ViewAllButton>
+              )}
             </Stack>
           </Stack>
 

--- a/src/hooks/useASP.ts
+++ b/src/hooks/useASP.ts
@@ -46,7 +46,7 @@ export const useASP = (
   });
 
   const isError = poolInfoQuery.isError || mtRootQuery.isError;
-  const isLoading = poolInfoQuery.isLoading || mtRootQuery.isLoading;
+  const isLoading = poolInfoQuery.isLoading || mtRootQuery.isLoading || mtLeavesQuery.isLoading;
 
   return useMemo(
     () => ({

--- a/src/hooks/useAdvancedView.ts
+++ b/src/hooks/useAdvancedView.ts
@@ -28,7 +28,7 @@ export const useAdvancedView = () => {
   const currentPage = Number(searchParams.get('page') || 1);
 
   const allEventsByPageQuery = useQuery({
-    queryKey: ['asp_all_events_by_page', currentPage, chainId],
+    queryKey: ['asp_all_events_by_page', currentPage, chainId, selectedPoolInfo.scope.toString()],
     queryFn: () => aspClient.fetchAllEvents(aspUrl, chainId, selectedPoolInfo.scope.toString(), currentPage),
     refetchInterval: 60000,
     retryOnMount: false,

--- a/src/hooks/useAdvancedView.ts
+++ b/src/hooks/useAdvancedView.ts
@@ -51,7 +51,7 @@ export const useAdvancedView = () => {
     return hideEmptyPools
       ? poolAccounts.filter((account) => formatUnits(account.balance, decimals) !== '0')
       : poolAccounts;
-  }, [poolAccounts, hideEmptyPools, selectedPoolInfo.scope, decimals]);
+  }, [poolAccounts, hideEmptyPools, decimals]);
 
   // Ordered pool accounts from newest to oldest and filter by selectedPoolInfo.scope
   const orderedPoolAccounts = useMemo(
@@ -62,7 +62,7 @@ export const useAdvancedView = () => {
     [filteredPoolAccounts, selectedPoolInfo.scope],
   );
 
-  const fullPoolAccounts = useMemo(() => orderedPoolAccounts, [orderedPoolAccounts, selectedPoolInfo.scope]);
+  const fullPoolAccounts = useMemo(() => orderedPoolAccounts, [orderedPoolAccounts]);
   const previewPoolAccounts = useMemo(() => orderedPoolAccounts.slice(0, 6), [orderedPoolAccounts]);
 
   const fullPersonalActivity = useMemo(() => orderedPersonalActivity, [orderedPersonalActivity]);

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -276,6 +276,7 @@ export const AccountProvider = ({ children }: Props) => {
         fetchAndProcessDeposits(currentScopeAccounts);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aspIsLoading, selectedPoolInfo.scope]);
 
   useEffect(() => {

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -53,7 +53,7 @@ export const AccountProvider = ({ children }: Props) => {
   const { selectedPoolInfo } = useChainContext();
   const { addNotification } = useNotifications();
   const {
-    aspData: { mtLeavesData, fetchDepositsByLabel, refetchMtLeaves, isError: aspError },
+    aspData: { mtLeavesData, fetchDepositsByLabel, refetchMtLeaves, isError: aspError, isLoading: aspIsLoading },
   } = useExternalServices();
   const { poolAccount, setPoolAccount } = usePoolAccountsContext();
 
@@ -247,8 +247,12 @@ export const AccountProvider = ({ children }: Props) => {
 
     const newPoolAccounts = poolAccountsByChainScope[`${selectedPoolInfo.chainId}-${selectedPoolInfo.scope}`];
     if (!!newPoolAccounts) {
+      setIsLoading(true);
       setPoolAccounts(newPoolAccounts);
-      fetchAndProcessDeposits(newPoolAccounts);
+      // Don't call fetchAndProcessDeposits if ASP is still loading the new scope data
+      if (!aspIsLoading) {
+        fetchAndProcessDeposits(newPoolAccounts);
+      }
     } else {
       if (poolAccounts.length > 0) {
         setPoolAccounts([]);
@@ -260,7 +264,19 @@ export const AccountProvider = ({ children }: Props) => {
     poolAccounts,
     poolAccountsByChainScope,
     fetchAndProcessDeposits,
+    aspIsLoading,
   ]);
+
+  // Handle when ASP loading completes
+  useEffect(() => {
+    if (!aspIsLoading && poolAccounts.length > 0 && accountServiceRef.current) {
+      // Check if we have pool accounts for the current scope that need processing
+      const currentScopeAccounts = poolAccounts.filter((pa) => pa.scope === selectedPoolInfo.scope);
+      if (currentScopeAccounts.length > 0) {
+        fetchAndProcessDeposits(currentScopeAccounts);
+      }
+    }
+  }, [aspIsLoading, selectedPoolInfo.scope]);
 
   useEffect(() => {
     if (aspError) {

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -11,6 +11,7 @@ interface AuthContextType {
   isConnected: boolean;
   login: (_seed?: string) => void;
   logout: () => void;
+  isAuthorized: boolean;
 }
 
 export const AuthContext = createContext({} as AuthContextType);
@@ -51,6 +52,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         isConnected: !!address,
         login,
         logout,
+        isAuthorized: isLogged && !!address,
       }}
     >
       {children}


### PR DESCRIPTION
## Describe your changes
- "View all" option in the "Pool accounts" section is incorrectly enabled
- Pool account status is outdated before switching tokens


https://github.com/user-attachments/assets/8a78a4b0-6e48-4ded-8183-69ee8ed28e4d



## Issue ticket number and link

closes 0XB-413 0XB-411

https://linear.app/defi-wonderland/issue/0XB-413/view-all-option-in-the-pool-accounts-section-is-incorrectly-enabled
https://linear.app/defi-wonderland/issue/0XB-411/pool-account-status-is-outdated-before-switching-tokens

## Checklist before requesting a review

- [ ] I have conducted a self-review of my code.
- [ ] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.
